### PR TITLE
Adjust mobile view with Switcher

### DIFF
--- a/src/views/DataDisplaySwitcher.css
+++ b/src/views/DataDisplaySwitcher.css
@@ -13,6 +13,17 @@
     flex-direction: row;
 }
 
+@media (max-width: 786px) {
+    .RowButtonToggle {
+        width: 16rem;
+        align-items: stretch;
+    }
+
+    .Switcher10KButton {
+        width: 100%;
+    }
+}
+
 .dark-layout .nav-pills .nav-item .nav-link.active {
     color:black;
 }

--- a/src/views/DataDisplaySwitcher.js
+++ b/src/views/DataDisplaySwitcher.js
@@ -21,7 +21,7 @@ const DataDisplaySwitcher = ({isShowPer10kAsian, onClick}) => {
                     <NavLink active={!isShowPer10kAsian} onClick={TotalButton}>
                         Total
                     </NavLink>
-                    <NavLink active={isShowPer10kAsian} onClick={Per10KAsianButton}>
+                    <NavLink className='Switcher10KButton' active={isShowPer10kAsian} onClick={Per10KAsianButton}>
                         Per 10K Asian
                     </NavLink>
                 </NavItem>

--- a/src/views/DateRangeSelector.js
+++ b/src/views/DateRangeSelector.js
@@ -31,9 +31,9 @@ const dateRanges = [
     value: [dateFns.startOfYear(new Date()), new Date()]
   },
 ];
-const DateRangeSelector = ({ onChange, value }) => {
+const DateRangeSelector = ({ onChange, value, isMobile }) => {
     return (
-      <DateRangePicker ranges={dateRanges} disabledDate={afterToday()} onChange={onChange} value={value} />
+      <DateRangePicker placement="auto" showOneCalendar={isMobile} ranges={dateRanges} disabledDate={afterToday()} onChange={onChange} value={value} />
     )
 }
 

--- a/src/views/Home.css
+++ b/src/views/Home.css
@@ -1,0 +1,24 @@
+@media (max-width: 786px) {
+    .OneRowItem {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        padding-bottom: 1rem;
+    }
+    
+    .rs-picker-toggle-wrapper {
+        width: 16rem
+    }
+    
+    .SimpleLabel {
+        margin-top: 1rem;
+    }
+
+    .title {
+        font-size: 1rem !important; 
+    }
+}
+
+.title {
+    font-size: 2rem;
+}

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -38,6 +38,7 @@ import Head from './components/head';
 import { useTranslation } from 'react-i18next';
 import { Trans } from 'react-i18next';
 import DataDisplaySwitcher from './DataDisplaySwitcher'
+import './Home.css'
 
 const Home = () => {
   const router = useRouter();
@@ -60,6 +61,7 @@ const Home = () => {
     });
   });
 
+  const isMobile = (window.innerWidth <= 786)
   const [isShowPer10kAsian, setIsShowPer10kAsian] = useState(false)
   const [incidents, setIncidents] = useState([]);
   const [selectedState, setSelectedState] = useState();
@@ -223,13 +225,22 @@ const Home = () => {
             <Col xs='12'>
               <Container className='header'>
                 <Row className='align-items-center'>
-                  <Col sm='8' xs='12'>
-                    <h4>
-                      <img src={logo} alt='logo' className='logo' />{' '}
+                <Col xs='12' sm='12' md='auto'>
+                    <p className='title'>
+                      <img src={logo} alt='logo' className='logo'  />{' '}
                       {t('website.name')}
-                    </h4>
+                    </p>
                   </Col>
-                  <Col sm='4' xs='12'>
+                  <Col xs='12' sm='12' md='auto'>
+                    <div className='OneRowItem'>
+                    <a
+                      href='https://docs.google.com/forms/d/1pWp89Y6EThMHml1jYGkDj5J0YFO74K_37sIlOHKkWo0'
+                      target='_blank'
+                      className='SimpleLabel'
+                    >
+                      {t('contact_us')}
+                    </a>
+                    &nbsp;&nbsp;
                     <SelectPicker
                       data={support_languages}
                       searchable={false}
@@ -238,36 +249,31 @@ const Home = () => {
                       style={{ width: 120 }}
                       onChange={(value) => setSelectedLang(value)}
                     />
-                    &nbsp;&nbsp;
-                    <a
-                      href='https://docs.google.com/forms/d/1pWp89Y6EThMHml1jYGkDj5J0YFO74K_37sIlOHKkWo0'
-                      target='_blank'
-                    >
-                      {t('contact_us')}
-                    </a>
+                    </div>
                   </Col>
                 </Row>
 
                 <FormGroup>
                   <Row>
-                    <Col xs='6' sm='auto'>
-                      <Label>{t('location')}:</Label>{' '}
+                    <Col xs='12' sm='12' md='auto' className='OneRowItem'>
+                      <Label className='SimpleLabel'>{t('location')}:</Label>{' '}
                       <StateSelection
                         name='state'
                         value={selectedState}
                         onChange={setSelectedState}
                       />{' '}
                     </Col>
-                    <Col xs='6' sm='auto'>
-                      <Label>{t('date_range')}:</Label>{' '}
+                    <Col xs='12' sm='12' md='auto' className='OneRowItem'>
+                      <Label className='SimpleLabel'>{t('date_range')}:</Label>{' '}
                       <DateRangeSelector
                         name='date'
                         onChange={handleDateRangeSelect}
                         value={dateRange}
+                        isMobile={isMobile}
                       />
                     </Col>
-                    <Col xs='6' sm='auto'>
-                      <Label>{t('data_display')}:</Label>{' '}
+                    <Col xs='12' sm='12' md='auto' className='OneRowItem'>
+                      <Label className='SimpleLabel'>{t('data_display')}:</Label>{' '}
                       <DataDisplaySwitcher isShowPer10kAsian={isShowPer10kAsian} onClick={() => setIsShowPer10kAsian(!isShowPer10kAsian)} />
                     </Col>
                   </Row>


### PR DESCRIPTION
Change the position of **dropdown choosing language**  to the right and **Contact** to the left,
-> in the phone view all dropdowns will be on the right and all titles will be on the left.

Change **< h >** of title Anti-Asian Hate Crime Tracker to **< p >** for more responsive. 
-> The old title is weirdly large on the small screen. 

**Important Note:**
This adjustment is fixed and tested on Ipad and iPhone view.

Screen size will be checked for the first render (not check all the time) to decide 2 screen calendar or 1 screen calendar
(should be 2 screen calendar on **Monitor view** and 1 screen calendar on **Phone view**)
**const isMobile = (window.innerWidth <= 786)**
If you change the screen size while testing, please reload the page again
-> I do not want to use **useState** for this because users don't change their screen size when surfing the web. 
-> Too much **useState** would slow down our page



